### PR TITLE
Fix display of ntools-highlight on D8 back-office.

### DIFF
--- a/ntools.user.js
+++ b/ntools.user.js
@@ -87,7 +87,7 @@ nToolsHelper = {
       nameLinks.append(links[i]);
     }
 
-    jQuery(node).append(
+    jQuery(node).css('position', 'relative').append(
       jQuery('<div></div>')
         .addClass('ntools-highlight')
         .append(


### PR DESCRIPTION
I think that as div.ntools-highlight has an absolute position, its parent needs to be set to relative if we want to display the highlight on top of the parent